### PR TITLE
Require minimal features from the image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ description = "Image comparison library based upon the image crate. Currently it
 
 [dependencies]
 thiserror = "1.0"
-image = "0.24"
+image = { version = "0.24", default-features = false }
 rayon = "1.7"
 itertools = "0.10"
 
 [dev-dependencies]
 cucumber = "0.19"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+image = { version = "0.24", default-features = false, features = ["png"] }
 
 [[test]]
 name = "compare"


### PR DESCRIPTION
The image crate comes with a generous set of default features (different image formats) that aren't directly used by this crate. By reducing the set of required features here, a downstream crate can use a small set of `image` features, and that choice won't be overridden by `image-compare`.

This helps a bit with compile time; in my project this results in 30 fewer dependencies.