### PR TITLE
Upgraded dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ description = "Image comparison library based upon the image crate. Currently it
 
 [dependencies]
 thiserror = "1.0"
-image = { version = "0.24", default-features = false }
-rayon = "1.7"
-itertools = "0.10"
+image = { version = "0.25", default-features = false }
+rayon = "1.9"
+itertools = "0.12"
 
 [dev-dependencies]
-cucumber = "0.19"
+cucumber = "0.20"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 [[test]]
 name = "compare"


### PR DESCRIPTION
Mainly for this crate to be compatible with `image@0.25`, but I've also upgraded the rest of the dependencies to their respective new minor versions.