### PR TITLE
fix: Calculate sum as f64 for images above 4096x4096

### DIFF
--- a/src/hybrid.rs
+++ b/src/hybrid.rs
@@ -56,7 +56,8 @@ fn merge_similarity_channels_yuva(
         },
     );
 
-    let score = deviation.iter().sum::<f32>() as f64 / deviation.len() as f64;
+    let score = deviation.iter().map(|s| *s as f64).sum::<f64>() / deviation.len() as f64;
+
     Similarity {
         image: image.into(),
         score,
@@ -84,7 +85,7 @@ fn merge_similarity_channels_yuv(input: &[GraySimilarityImage; 3]) -> Similarity
         *rgb = Rgb([1. - y, 1. - u, 1. - v]);
     });
 
-    let score = deviation.iter().sum::<f32>() as f64 / deviation.len() as f64;
+    let score = deviation.iter().map(|s| *s as f64).sum::<f64>() / deviation.len() as f64;
     Similarity {
         image: image.into(),
         score,

--- a/tests/features/hybrid_rgb.feature
+++ b/tests/features/hybrid_rgb.feature
@@ -14,7 +14,7 @@ Then the similarity score is <result>
 Examples:
 | compare_image                           | result                |
 | tests/data/pad_gaprao.png               | 1.0                   |
-| tests/data/pad_gaprao_lighter.png       | 0.948974609375        |
-| tests/data/pad_gaprao_noise.png         | 0.13009302571614584   |
-| tests/data/pad_gaprao_gray_inverted.png | 3.256663878758748e-5  |
-| tests/data/pad_gaprao_color_filters.png | 0.9884529947916667    |
+| tests/data/pad_gaprao_lighter.png       | 0.9514066504143178    |
+| tests/data/pad_gaprao_noise.png         | 0.13009783371684705   |
+| tests/data/pad_gaprao_gray_inverted.png | 3.2566565189821024e-5 |
+| tests/data/pad_gaprao_color_filters.png | 0.9876923700357477    |

--- a/tests/features/hybrid_rgba.feature
+++ b/tests/features/hybrid_rgba.feature
@@ -9,17 +9,17 @@ Feature: RGBA image comparison using hybrid mode - MSSIM for for Y, Alpha channe
     Given the images 'tests/data/100/hand_white.png' and 'tests/data/100/typed_alpha.png' are loaded
     When comparing the images using the hybrid mode as rgba
     Then the rgba similarity image matches 'tests/data/100/diff_100_hand_alpha.png'
-    And the similarity score is 0.00635866355150938
+    And the similarity score is 0.006358610363005692
 
   Scenario: Comparing two images where one is transparent in front of black background
     Given the images 'tests/data/100/hand_white.png' and 'tests/data/100/typed_alpha.png' are loaded
     When comparing the images using the blended hybrid mode with 'black' background
-    Then the similarity score is 0.007445383816957474
+    Then the similarity score is 0.007447309291571148
 
   Scenario: Comparing two images where one is transparent in front of white background
     Given the images 'tests/data/100/hand_white.png' and 'tests/data/100/typed_alpha.png' are loaded
     When comparing the images using the blended hybrid mode with 'white' background
-    Then the similarity score is 0.6302585601806641
+    Then the similarity score is 0.6303176177525529
 
 
 
@@ -28,7 +28,7 @@ Feature: RGBA image comparison using hybrid mode - MSSIM for for Y, Alpha channe
     Given the images 'tests/data/100/typed_alpha.png' and 'tests/data/100/typed_color_changed.png' are loaded
     When comparing the images using the hybrid mode as rgba
     Then the rgba similarity image matches 'tests/data/100/diff_100_typed_colors.png'
-    And the similarity score is 0.9748366475105286
+    And the similarity score is 0.9748343863750435
 
   Scenario Outline: Comparing a modified image to the original using hybrid mode algorithm
     Given the images 'tests/data/pad_gaprao.png' and '<compare_image>' are loaded
@@ -38,8 +38,8 @@ Feature: RGBA image comparison using hybrid mode - MSSIM for for Y, Alpha channe
     Examples:
       | compare_image                           | result                |
       | tests/data/pad_gaprao.png               | 1.0                   |
-      | tests/data/pad_gaprao_lighter.png       | 0.948974609375        |
-      | tests/data/pad_gaprao_noise.png         | 0.13009302571614584   |
-      | tests/data/pad_gaprao_gray_inverted.png | 3.256663878758748e-5  |
-      | tests/data/pad_gaprao_color_filters.png | 0.9884529947916667    |
-      | tests/data/pad_gaprao_alpha.png         | 0.9541552734375    |
+      | tests/data/pad_gaprao_lighter.png       | 0.9514066504143178    |
+      | tests/data/pad_gaprao_noise.png         | 0.13009783371684705   |
+      | tests/data/pad_gaprao_gray_inverted.png | 3.2566565189821024e-5 |
+      | tests/data/pad_gaprao_color_filters.png | 0.9876923700357477    |
+      | tests/data/pad_gaprao_alpha.png         | 0.9540830736098154    |


### PR DESCRIPTION
Hi,

I found a bug when comparing images with a very high resolution, with a pixel count above `16777216` to be precise. This happens because `16777216` is a maximum safe integer that can be stored in f32,

You can check it, as the following test passes:

```rust
#[test]
fn f32_test() {
    assert_eq!(16777216.0f32 + 1.0, 16777216.0f32)
}
```

When comparing the large image to themselves, the deviation array contains only elements `1.0`, and `sum::<f32>` essentially increments an accumulator by `1.0` in a loop, which clips at `16777216`, and if the pixel count was higher, the later division by element count yields score lower than `1.0`.

This PR properly casts each element to f64 before calculating the sum with f64 accumulator, which solves this problem (since the maximum safe integer in f64 is about `9**15`)


### Note

I wasn't sure how to cover it with tests, since
- I don't fully understand how it fits cucumber
- In debug build this test takes 27 seconds to run on a AMD 3900x CPU (0.43s in release build)

```rust
#[test]
fn check_image_with_pixel_count_overflowing_f32() {
    let image = image::RgbaImage::from_vec(1, 16777300, vec![0; 16777300 * 4]).unwrap();

    // Fails right now on main branch with score 0.9999949932349067
    assert_eq!(
        image_compare::rgba_hybrid_compare(&image, &image)
            .expect("Could not compare")
            .score,
        1.0
    );
}
```